### PR TITLE
Remove debugging global auth helper

### DIFF
--- a/src/boot/auth-header.ts
+++ b/src/boot/auth-header.ts
@@ -178,10 +178,3 @@ const XS = XMLHttpRequest.prototype.send;
 
   return XS.call(this, body);
 };
-
-// Optional helper exposed for debugging
-(window as any).__ccfAuth = {
-  getToken,
-  setToken,
-  clearToken,
-};


### PR DESCRIPTION
Exposing authentication token management functions on the window object creates an unnecessary attack surface. Malicious scripts, browser extensions, or XSS vulnerabilities could abuse these functions to extract, modify, or clear user JWT tokens.

The global auth helper that we're removing here was only ever intended to be temporary, to aid with debugging. Now that we have a successful deployment on Railway there's definitely no need to retain it.

The internal helper functions remain intact for the authentication system's proper operation; only the debug-time global exposure is removed. Production code should never leak internal APIs to the global scope.

As per #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal debugging utilities. No functional changes to authentication or token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->